### PR TITLE
modules/find.py: Disallow ".", ":" and "-" as separators

### DIFF
--- a/modules/find.py
+++ b/modules/find.py
@@ -161,8 +161,9 @@ def findandreplace(jenni, input):
     if me and not input.group(1): phrase = '\x02' + phrase + '\x02'
     jenni.say(phrase)
 
-# Matches optional whitespace + 's' + optional whitespace + separator character
-findandreplace.rule = r'(?iu)(?:([^\s:,]+)[\s:,])?\s*s\s*([^\s\w])(.*)' # May work for both this and "meant" (requires input.group(i+1))
+# Matches optional whitespace + 's' + optional whitespace + separator character.
+# The separator can be any non-alphanumeric character except for '_', '.', ':' and '-'.
+findandreplace.rule = r'(?iu)(?:([^\s:,]+)[\s:,])?\s*s\s*([^\s\w.:-])(.*)' # May work for both this and "meant" (requires input.group(i+1))
 findandreplace.priority = 'high'
 findandreplace.rate = 30
 


### PR DESCRIPTION
Rationale: they may occur in IP addresses and hostnames. For example, I recently accidentally triggered this:

    <lyoko1> what's up with cadoth
    -snip-
    <lyoko1> s.cadoth.net:2200
    <jenn1> lyoko1 probably meant to say: what's up with net:2200