### PR TITLE
fix jenni hanging when not using SASL or password

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -218,7 +218,8 @@ class Bot(asynchat.async_chat):
         if self.verbose:
             print >> sys.stderr, 'connected!'
 
-        self.write(('CAP', 'LS'))
+        if self.use_sasl:
+            self.write(('CAP', 'LS'))
 
         if not self.use_sasl and self.password:
             self.write(('PASS', self.password))


### PR DESCRIPTION
If jenni isn't configured to use SASL, a CAP LS was still sent, but the
module is disabled so no CAP END is send after recieving CAP * LS from
the server, leading to a hang. This makes it so that if there's no SASL,
jenni doesn't even begin the CAP handshake. Fixes #149 