### PR TITLE
print registered modules in sorted order

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -83,7 +83,7 @@ class Jenni(irc.Bot):
                 modules.append(name)
 
         if modules:
-            print >> sys.stderr, 'Registered modules:', ', '.join(modules)
+            print >> sys.stderr, 'Registered modules:', ', '.join(sorted(modules))
         else: print >> sys.stderr, "Warning: Couldn't find any modules"
 
         self.bind_commands()


### PR DESCRIPTION
print the registered modules in sorted order, then print the patterns and corresponding functions in a more easy-to-read and sorted fashion