### PR TITLE
[abjonnes-sorted_modules] Sorting modules

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -83,8 +83,9 @@ class Jenni(irc.Bot):
                 modules.append(name)
 
         if modules:
-            print >> sys.stderr, 'Registered modules:', ', '.join(modules)
-        else: print >> sys.stderr, "Warning: Couldn't find any modules"
+            print >> sys.stderr, 'Registered modules:', ', '.join(sorted(modules))
+        else:
+            print >> sys.stderr, "Warning: Couldn't find any modules"
 
         self.bind_commands()
 
@@ -98,7 +99,6 @@ class Jenni(irc.Bot):
         self.commands = {'high': {}, 'medium': {}, 'low': {}}
 
         def bind(self, priority, regexp, func):
-            print priority, regexp.pattern.encode('utf-8'), func
             # register documentation
             if not hasattr(func, 'name'):
                 func.name = func.__name__
@@ -109,12 +109,15 @@ class Jenni(irc.Bot):
                 else: example = None
                 self.doc[func.name] = (func.__doc__, example)
             self.commands[priority].setdefault(regexp, []).append(func)
+            regexp = re.sub('\x01|\x02', '', regexp.pattern)
+            return (func.__module__, func.__name__, regexp, priority)
 
         def sub(pattern, self=self):
             # These replacements have significant order
             pattern = pattern.replace('$nickname', re.escape(self.nick))
             return pattern.replace('$nick', r'%s[,:] +' % re.escape(self.nick))
 
+        bound_funcs = []
         for name, func in self.variables.iteritems():
             # print name, func
             if not hasattr(func, 'priority'):
@@ -141,7 +144,7 @@ class Jenni(irc.Bot):
                 if isinstance(func.rule, str):
                     pattern = sub(func.rule)
                     regexp = re.compile(pattern)
-                    bind(self, func.priority, regexp, func)
+                    bound_funcs.append(bind(self, func.priority, regexp, func))
 
                 if isinstance(func.rule, tuple):
                     # 1) e.g. ('$nick', '(.*)')
@@ -149,7 +152,7 @@ class Jenni(irc.Bot):
                         prefix, pattern = func.rule
                         prefix = sub(prefix)
                         regexp = re.compile(prefix + pattern)
-                        bind(self, func.priority, regexp, func)
+                        bound_funcs.append(bind(self, func.priority, regexp, func))
 
                     # 2) e.g. (['p', 'q'], '(.*)')
                     elif len(func.rule) == 2 and isinstance(func.rule[0], list):
@@ -158,7 +161,7 @@ class Jenni(irc.Bot):
                         for command in commands:
                             command = r'(?i)(%s)\b(?: +(?:%s))?' % (command, pattern)
                             regexp = re.compile(prefix + command)
-                            bind(self, func.priority, regexp, func)
+                            bound_funcs.append(bind(self, func.priority, regexp, func))
 
                     # 3) e.g. ('$nick', ['p', 'q'], '(.*)')
                     elif len(func.rule) == 3:
@@ -167,14 +170,19 @@ class Jenni(irc.Bot):
                         for command in commands:
                             command = r'(?i)(%s) +' % command
                             regexp = re.compile(prefix + command + pattern)
-                            bind(self, func.priority, regexp, func)
+                            bound_funcs.append(bind(self, func.priority, regexp, func))
 
             if hasattr(func, 'commands'):
                 for command in func.commands:
                     template = r'(?i)^%s(%s)(?: +(.*))?$'
                     pattern = template % (self.config.prefix, command)
                     regexp = re.compile(pattern)
-                    bind(self, func.priority, regexp, func)
+                    bound_funcs.append(bind(self, func.priority, regexp, func))
+
+        max_pattern_width = max(len(f[2]) for f in bound_funcs)
+        for module, name, regexp, priority in sorted(bound_funcs):
+            encoded_regex = regexp.encode('utf-8').ljust(max_pattern_width)
+            print ('{0} | {1}.{2}, {3} priority'.format(encoded_regex,  module, name, priority))
 
     def wrapped(self, origin, text, match):
         class JenniWrapper(object):
@@ -342,3 +350,4 @@ class Jenni(irc.Bot):
 
 if __name__ == '__main__':
     print __doc__
+


### PR DESCRIPTION
- print the registered modules in sorted order, then print the patterns and corresponding functions in a more easy-to-read and sorted fashion
- Updated from https://github.com/myano/jenni/pull/164 and https://github.com/myano/jenni/pull/168