### PR TITLE
Fix Windows compatibility

### DIFF
--- a/jenni
+++ b/jenni
@@ -21,7 +21,7 @@ from textwrap import dedent as trim
 dotdir = os.path.expanduser('~/.jenni')
 configpath = os.path.expanduser(dotdir + '/default.py')
 
-if os.geteuid() == 0:
+if getattr(os, 'geteuid', None) and os.geteuid() == 0:
     error = 'Error: Refusing to run as root.'
     print >> sys.stderr, error
     sys.exit(1)


### PR DESCRIPTION
Since Windows doesn't have `geteuid()`, jenni fails to start there since commit 8416ab1.

[Reported][1] by @rubahness.

[1]: https://github.com/myano/jenni/commit/8416ab145e5d618bc7639887862ecd34d5753601#commitcomment-11035302