### PR TITLE
startup: extend the sleep after identify'ing with nickserv to delay join

### DIFF
--- a/modules/startup.py
+++ b/modules/startup.py
@@ -63,7 +63,7 @@ def startup(jenni, input):
 
     if not jenni.is_authenticated and hasattr(jenni.config, 'password'):
         jenni.msg('NickServ', 'IDENTIFY %s' % jenni.config.password)
-        time.sleep(5)
+        time.sleep(10)
 
     # Cf. http://swhack.com/logs/2005-12-05#T19-32-36
     for channel in jenni.channels:


### PR DESCRIPTION
The IDENTIFY step often takes more than 5s to complete.  If the JOINs
happen before IDENTIFY completes, the bot's vhost/cloak will not have
been applied prior to the JOINs being executed.

Increasing this delay makes it more likely (but obviously not guaranteed)
that the bot's vhost has been applied early enough.