### PR TITLE
[RFC] Fix setattr on wrapped class

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -202,6 +202,9 @@ class Jenni(irc.Bot):
                 if attr in ('bot',):
                     # Allow a limited set of attributes to be set on the wrapper itself
                     return super(JenniWrapper, self).__setattr__(attr, value)
+                elif attr in ('is_authenticated', 'is_connected'):
+                    # Allow a limited set of attributes to be set on the wrapped class
+                    return setattr(self.bot, attr, value)
                 else:
                     raise(Exception("Setting attribute '%s' is not allowed" % (attr,)))
 

--- a/bot.py
+++ b/bot.py
@@ -198,6 +198,13 @@ class Jenni(irc.Bot):
                     return lambda msg: self.bot.msg(sender, msg)
                 return getattr(self.bot, attr)
 
+            def __setattr__(self, attr, value):
+                if attr in ('bot',):
+                    # Allow a limited set of attributes to be set on the wrapper itself
+                    return super(JenniWrapper, self).__setattr__(attr, value)
+                else:
+                    raise(Exception("Setting attribute '%s' is not allowed" % (attr,)))
+
         return JenniWrapper(self)
 
     def input(self, origin, text, bytes, match, event, args):


### PR DESCRIPTION
This is a request for comments since this could cause explicit breakage on various modules where the bahaviour was formerly allowed, but silently had no effect.

Some modules are setting/updating attributes expecting them to be globally visible but because the modules only see a wrapped version of the 'jenni' object, all of these updates are lost immediately after the call to the module's method.

See: usage of is_authenticated and is_connected in startup.py and sasl.py

This is directly visible by watching the log when SASL auth succeeds and noting that startup.py still initiates the IDENTIFY with nickserv.  This is due to startup.py seeing ```is_authenticated``` as ```False``` rather than the (lost in wrapped version) ```True``` set by sasl.py.

Specifically, the 903 handling in sasl.py sets ```jenni.is_authenticated = True```.  That cannot ever be seen outside of this call since it is only set in the wrapped class, not the "real" jenni instance.

This patch set allows these attributes to be set on the top-level jenni instance.  It also dumps a traceback to the console for all other uses of setattr on the wrapped class since they will not have the expected effect since they vanish immediately.