### PR TITLE
auth: allow config of independent user and nick parameters for auth

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -33,7 +33,9 @@ class Jenni(irc.Bot):
         if hasattr(config, 'ipv6'): ipv6 = config.ipv6
         serverpass = None
         if hasattr(config, 'serverpass'): serverpass = config.serverpass
-        args = (config.nick, config.name, config.channels, serverpass, lc_pm, logging, ipv6)
+        user = None
+        if hasattr(config, 'user'): user = config.user
+        args = (config.nick, config.name, config.channels, user, serverpass, lc_pm, logging, ipv6)
         ## next, try putting a try/except around the following line
         irc.Bot.__init__(self, *args)
         self.config = config

--- a/irc.py
+++ b/irc.py
@@ -75,13 +75,16 @@ def log_raw(line):
     f.close()
 
 class Bot(asynchat.async_chat):
-    def __init__(self, nick, name, channels, password=None, logchan_pm=None, logging=False, ipv6=False):
+    def __init__(self, nick, name, channels, user=None, password=None, logchan_pm=None, logging=False, ipv6=False):
         asynchat.async_chat.__init__(self)
         self.set_terminator('\n')
         self.buffer = ''
 
         self.nick = nick
-        self.user = nick
+        if user is not None:
+            self.user = user
+        else:
+            self.user = nick
         self.name = name
         self.password = password
 

--- a/jenni
+++ b/jenni
@@ -53,6 +53,10 @@ def create_default_config(fn):
     # For example: yano@unaffiliated/yano
     owner = 'yournickname'
 
+    # user is the NickServ userid
+    # This is useful if your NickServ user is different than the nick you are using
+    # user = 'userid'
+
     # password is the NickServ password, serverpass is the server password
     # password = 'example'
     # serverpass = 'serverpass'

--- a/modules/sasl.py
+++ b/modules/sasl.py
@@ -46,7 +46,16 @@ irc_cap.priority = 'high'
 def irc_authenticated (jenni, input):
     auth = False
     if hasattr(jenni.config, 'nick') and jenni.config.nick is not None and hasattr(jenni.config, 'password') and jenni.config.password is not None:
-        auth = "\0".join((jenni.config.nick, jenni.config.nick, jenni.config.password))
+        nick = jenni.config.nick
+        password = jenni.config.password
+
+        # If provided, use the specified user for authentication, otherwise just use the nick
+        if hasattr(jenni.config, 'user') and jenni.config.user is not None:
+            user = jenni.config.user
+        else:
+            user = nick
+
+        auth = "\0".join((nick, user, password))
         auth = base64.b64encode(auth)
 
     if not auth:

--- a/modules/startup.py
+++ b/modules/startup.py
@@ -62,7 +62,12 @@ def startup(jenni, input):
         jenni.write(('PASS', jenni.config.serverpass))
 
     if not jenni.is_authenticated and hasattr(jenni.config, 'password'):
-        jenni.msg('NickServ', 'IDENTIFY %s' % jenni.config.password)
+        if hasattr(jenni.config, 'user') and jenni.config.user is not None:
+            user = jenni.config.user
+        else:
+            user = jenni.config.nick
+
+        jenni.msg('NickServ', 'IDENTIFY %s %s' % (user, jenni.config.password))
         time.sleep(10)
 
     # Cf. http://swhack.com/logs/2005-12-05#T19-32-36


### PR DESCRIPTION
This allows the nick and the NickServ user to be independent from one another.  This new 'user' config is used in the irc USER command, the NickServ IDENTIFY command and in the SASL AUTHENTICATE command.

jenni previously assumed that the nick was identical to the nickserv user which may not be true.