### PR TITLE
Fix setattr on wrapped class

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -187,16 +187,16 @@ class Jenni(irc.Bot):
     def wrapped(self, origin, text, match):
         class JenniWrapper(object):
             def __init__(self, jenni):
-                self.bot = jenni
+                self._bot = jenni
 
             def __getattr__(self, attr):
                 sender = origin.sender or text
                 if attr == 'reply':
                     return (lambda msg:
-                        self.bot.msg(sender, origin.nick + ': ' + msg))
+                        self._bot.msg(sender, origin.nick + ': ' + msg))
                 elif attr == 'say':
-                    return lambda msg: self.bot.msg(sender, msg)
-                return getattr(self.bot, attr)
+                    return lambda msg: self._bot.msg(sender, msg)
+                return getattr(self._bot, attr)
 
         return JenniWrapper(self)
 

--- a/bot.py
+++ b/bot.py
@@ -205,6 +205,14 @@ class Jenni(irc.Bot):
                     return self._bot
                 return getattr(self._bot, attr)
 
+            def __setattr__(self, attr, value):
+                if attr in ('_bot',):
+                    # Explicitly allow the wrapped class to be set during __init__()
+                    return super(JenniWrapper, self).__setattr__(attr, value)
+                else:
+                    # All other attributes will be set on the wrapped class transparently
+                    return setattr(self._bot, attr, value)
+
         return JenniWrapper(self)
 
     def input(self, origin, text, bytes, match, event, args):

--- a/bot.py
+++ b/bot.py
@@ -196,6 +196,13 @@ class Jenni(irc.Bot):
                         self._bot.msg(sender, origin.nick + ': ' + msg))
                 elif attr == 'say':
                     return lambda msg: self._bot.msg(sender, msg)
+                elif attr == 'bot':
+                    # Allow deprecated usage of jenni.bot.foo but print a warning to the console
+                    print "Warning: Direct access to jenni.bot.foo is deprecated.  Please use jenni.foo instead."
+                    import traceback
+                    traceback.print_stack()
+                    # Let this keep working by passing it transparently to _bot
+                    return self._bot
                 return getattr(self._bot, attr)
 
         return JenniWrapper(self)

--- a/modules/head.py
+++ b/modules/head.py
@@ -25,7 +25,7 @@ def head(jenni, input):
     else: uri, header = uri, None
 
     if not uri and hasattr(jenni, 'last_seen_uri'):
-        try: uri = jenni.bot.last_seen_uri[input.sender]
+        try: uri = jenni.last_seen_uri[input.sender]
         except KeyError: return jenni.say('?')
 
     if not uri.startswith('htt'):

--- a/modules/search.py
+++ b/modules/search.py
@@ -83,8 +83,8 @@ def g(jenni, input):
             uri = uri.replace('http:', 'https:')
         jenni.reply(uri)
         if not hasattr(jenni, 'last_seen_uri'):
-            jenni.bot.last_seen_uri = {}
-        jenni.bot.last_seen_uri[input.sender] = uri
+            jenni.last_seen_uri = {}
+        jenni.last_seen_uri[input.sender] = uri
     elif uri is False: jenni.reply("Problem getting data from Google.")
     else: jenni.reply("No results found for '%s'." % query)
 g.commands = ['g']
@@ -152,8 +152,8 @@ def bing(jenni, input):
     if uri:
         jenni.reply(uri)
         if not hasattr(jenni, 'last_seen_uri'):
-            jenni.bot.last_seen_uri = {}
-        jenni.bot.last_seen_uri[input.sender] = uri
+            jenni.last_seen_uri = {}
+        jenni.last_seen_uri[input.sender] = uri
     else: jenni.reply("No results found for '%s'." % query)
 bing.commands = ['bing']
 bing.example = '.bing swhack'
@@ -275,15 +275,15 @@ def duck(jenni, input):
     uri = duck_search(query)
     if uri:
         jenni.say(uri)
-        if hasattr(jenni, 'last_seen_uri') and input.sender in jenni.bot.last_seen_uri:
-            jenni.bot.last_seen_uri[input.sender] = uri
+        if hasattr(jenni, 'last_seen_uri') and input.sender in jenni.last_seen_uri:
+            jenni.last_seen_uri[input.sender] = uri
 
     ## try to find any Zero-Click stuff
     result = duck_zero_click_api(query)
 
     if result and len(result) == 1:
-        if hasattr(jenni, 'last_seen_uri') and input.sender in jenni.bot.last_seen_uri:
-            jenni.bot.last_seen_uri[input.sender] = result[0]
+        if hasattr(jenni, 'last_seen_uri') and input.sender in jenni.last_seen_uri:
+            jenni.last_seen_uri[input.sender] = result[0]
 
     ## loop through zero-click results
     if result and len(result) >= 1:

--- a/modules/seen.py
+++ b/modules/seen.py
@@ -21,11 +21,11 @@ def f_seen(jenni, input):
         return jenni.say('Please provide a nick.')
     nick = input.group(2).lower()
 
-    if not hasattr(jenni.bot, 'seen'):
+    if not hasattr(jenni, 'seen'):
         return jenni.reply('?')
 
-    if jenni.bot.seen.has_key(nick):
-        channel, t = jenni.bot.seen[nick]
+    if jenni.seen.has_key(nick):
+        channel, t = jenni.seen[nick]
         t = time.strftime('%Y-%m-%d %H:%M:%S UTC', time.gmtime(t))
         msg = 'I last saw %s at %s in some channel.' % (nick, t)
         jenni.say(msg)
@@ -36,10 +36,10 @@ f_seen.rate = 15
 
 def f_note(jenni, input):
     try:
-        if not hasattr(jenni.bot, 'seen'):
-            jenni.bot.seen = dict()
+        if not hasattr(jenni, 'seen'):
+            jenni.seen = dict()
         if input.sender.startswith('#'):
-            jenni.bot.seen[input.nick.lower()] = (input.sender, time.time())
+            jenni.seen[input.nick.lower()] = (input.sender, time.time())
     except Exception, e: print e
 f_note.rule = r'(.*)'
 f_note.priority = 'low'

--- a/modules/twitter.py
+++ b/modules/twitter.py
@@ -110,8 +110,8 @@ def twitter(jenni, input):
     arg = input.group(2)
 
     if not arg:
-        if hasattr(jenni, 'last_seen_uri') and input.sender in jenni.bot.last_seen_uri:
-            temp = jenni.bot.last_seen_uri[input.sender]
+        if hasattr(jenni, 'last_seen_uri') and input.sender in jenni.last_seen_uri:
+            temp = jenni.last_seen_uri[input.sender]
             if '//twitter.com' in temp:
                 arg = temp
             else:

--- a/modules/unobot.py
+++ b/modules/unobot.py
@@ -141,7 +141,7 @@ class UnoBot:
             jenni.msg(CHANNEL, STRINGS['CANT_STOP'] % (self.game_on, self.timeout.seconds - (tmptime - self.lastActive).seconds))
 
     def join(self, jenni, input):
-        #print dir(jenni.bot)
+        #print dir(jenni)
         #print dir(input)
         nickk = (input.nick).lower()
         if self.game_on:

--- a/modules/url.py
+++ b/modules/url.py
@@ -77,8 +77,8 @@ HTML_ENTITIES = { 'apos': "'" }
 def noteuri(jenni, input):
     uri = input.group(1).encode('utf-8')
     if not hasattr(jenni, 'last_seen_uri'):
-        jenni.bot.last_seen_uri = {}
-    jenni.bot.last_seen_uri[input.sender] = uri
+        jenni.last_seen_uri = {}
+    jenni.last_seen_uri[input.sender] = uri
 noteuri.rule = r'(?u).*(http[s]?://[^<> "\x01]+)[,.]?'
 noteuri.priority = 'low'
 
@@ -285,8 +285,8 @@ def short(text):
 def generateBitLy(jenni, input):
     url = input.group(2)
     if not url:
-        if hasattr(jenni, 'last_seen_uri') and input.sender in jenni.bot.last_seen_uri:
-            url = jenni.bot.last_seen_uri[input.sender]
+        if hasattr(jenni, 'last_seen_uri') and input.sender in jenni.last_seen_uri:
+            url = jenni.last_seen_uri[input.sender]
         else:
             return jenni.say('No URL provided')
 
@@ -481,9 +481,9 @@ def show_title_demand(jenni, input):
     if not uri:
         channel = input.sender
         if not hasattr(jenni, 'last_seen_uri'):
-            jenni.bot.last_seen_uri = dict()
-        if channel in jenni.bot.last_seen_uri:
-            uri = jenni.bot.last_seen_uri[channel]
+            jenni.last_seen_uri = dict()
+        if channel in jenni.last_seen_uri:
+            uri = jenni.last_seen_uri[channel]
         else:
             return jenni.say('No recent links seen in this channel.')
 
@@ -513,8 +513,8 @@ def collect_links(jenni, input):
     channel = input.sender
     link = link[0]
     if not hasattr(jenni, 'last_seen_uri'):
-        jenni.bot.last_seen_uri = dict()
-    jenni.bot.last_seen_uri[channel] = link
+        jenni.last_seen_uri = dict()
+    jenni.last_seen_uri[channel] = link
 collect_links.rule = '(?iu).*(%s?(http|https)(://\S+)).*' % (EXCLUSION_CHAR)
 collect_links.priority = 'low'
 
@@ -525,8 +525,8 @@ def unbitly(jenni, input):
     '''.longurl <link> -- obtain the final destination URL from a short URL'''
     url = input.group(2)
     if not url:
-        if hasattr(jenni, 'last_seen_uri') and input.sender in jenni.bot.last_seen_uri:
-            url = jenni.bot.last_seen_uri[input.sender]
+        if hasattr(jenni, 'last_seen_uri') and input.sender in jenni.last_seen_uri:
+            url = jenni.last_seen_uri[input.sender]
         else:
             return jenni.say('No URL provided')
     if not url.startswith(('http://', 'https://')):


### PR DESCRIPTION
Some modules are setting/updating attributes expecting them to be globally visible but because the modules only see a wrapped version of the 'jenni' object, all of these updates are lost immediately after the call to the module's method.

See: usage of is_authenticated and is_connected in startup.py and sasl.py

This is directly visible by watching the log when SASL auth succeeds and noting that startup.py still initiates the IDENTIFY with nickserv. This is due to startup.py seeing is_authenticated as False rather than the (lost in wrapped version) True set by sasl.py.

Specifically, the 903 handling in sasl.py sets jenni.is_authenticated = True. That cannot ever be seen outside of this call since it is only set in the wrapped class, not the "real" jenni instance.

This patch set does the following:
* Hide the ```bot``` (wrapped class) as ```_bot```
* Allow getattr on ```bot``` to continue to work by passing it to ```_bot``` **but** also dump a deprecation warning with traceback to the console
* Fix the setattr on the wrapped jenni class so that setting an attribute on ```jenni.foo``` modifies the top-level jenni instance and is preserved across calls to module handlers
* Remove all usage of ```jenni.bot.foo``` and replace with direct access to ```jenni.foo```

This should fix the auth related bug without breaking any existing in-tree (or out-of-tree) usage of the wrapped class.  I've tested this, but don't have all modules active on my bot.  Could use some testing on a full version of jenni.

