### PR TITLE
Add jenni.brain for saving data to disk

### DIFF
--- a/jenni
+++ b/jenni
@@ -95,6 +95,13 @@ def create_default_config(fn):
         'token_secret': ''
         }
 
+    # Specify a path to enable brain.py to save data that modules might be
+    # using. If no path is specified data will only be stored in memory and not
+    # saved through reloading or restarting Jenni.
+    brain = {
+        'path': None,
+    }
+
     # These are people who will be able to use admin.py's functions...
     admins = [owner, 'someoneyoutrust']
     # But admin.py is disabled by default, as follows:

--- a/modules/brain.py
+++ b/modules/brain.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""
+brain.py - Store data on disk
+Copyright 2015, Britt Gresham (www.brittg.com)
+Licensed under the Eiffel Forum License 2.
+
+More info:
+ * jenni: https://github.com/myano/jenni/
+ * Phenny: http://inamidst.com/phenny/
+
+This module allows other modules to store information in memory for other
+modules to read from or write to. This module intentionally does not have any
+user facing commands.
+
+To save to a json file jenni's configuration needs to have a path specified in
+jenni.config.brain['path'] otherwise data will only be stored in memory instead.
+
+How to integrate brain.py into your module:
+
+import random
+
+def excuses(jenni, msg):
+    if 'excuses' not in jenni.brain:
+        jenni.brain['excuses'] = []
+    excuse = msg.group(1)
+    jenni.brain['excuses'].append(excuse)
+    jenni.save()
+excuses.commands = ['excuses']
+
+def print_excuse(jenni, msg):
+    excuses = jenni.brain.get('excuses')
+    if excuses:
+        jenni.reply(random.choice(excuses))
+    else:
+        jenni.reply('Add an excuse first')
+print_excuse.commands = ['print_excuse']
+"""
+
+import os
+import json
+
+
+class Brain(dict):
+
+    def __init__(self, jenni, brain_path=None):
+        self.jenni = jenni
+        self.brain_path = brain_path
+        initial_data = {}
+        if self.brain_path:
+            self.brain_path = os.path.expanduser(self.brain_path)
+            if os.path.isfile(self.brain_path):
+                f = open(self.brain_path, 'r')
+                payload = f.read()
+                f.close()
+                if payload:
+                    initial_data = json.loads(payload)
+        dict.__init__(self, initial_data)
+
+    def save(self):
+        if not self.brain_path:
+            return
+        with open(self.brain_path, 'w') as f:
+            f.write(json.dumps(self))
+
+
+def setup(jenni):
+    brain_path = None
+    if hasattr(jenni.config, 'brain'):
+        brain_path = jenni.config.brain.get('path')
+
+    jenni.brain = Brain(jenni, brain_path=brain_path)


### PR DESCRIPTION
This commit adds in the brain.py module which adds the brain attribute
onto the jenni object that is passed into other commands during normal
usage of jenni. Other modules can utilize this module to store
information through restarts and reloads by running jenni.brain.save()
and can manually reload the brain by running jenni.brain.load()

This is a proposal to solve Issue #107 regarding modules not having a single location to store information.
