### PR TITLE
Request quotes either by index or nick

### DIFF
--- a/modules/quote.py
+++ b/modules/quote.py
@@ -10,6 +10,7 @@ More info:
 """
 
 import random
+import itertools
 from modules import unicode as uc
 
 def write_addquote(text):
@@ -35,7 +36,7 @@ addquote.example = '.addquote'
 
 
 def retrievequote(jenni, input):
-    '''.quote <number> -- displays a given quote'''
+    '''.quote <number | nick> -- displays a given quote'''
     NO_QUOTES = 'There are currently no quotes saved.'
     text = input.group(2)
     try:
@@ -49,11 +50,25 @@ def retrievequote(jenni, input):
     MAX = len(lines)
     fn.close()
     random.seed()
-    try:
-        number = int(text)
-        if number < 0:
-            number = MAX - abs(number) + 1
-    except:
+
+    if text != None:
+        try:
+            number = int(text)
+            if number < 0:
+                number = MAX - abs(number) + 1
+        except:
+            nick = "<" + text + ">"
+
+            indices = range(1, len(lines) + 1)
+            selectors = map(lambda x: x.split()[0] == nick, lines)
+            filtered_indices = list(itertools.compress(indices, selectors))
+
+            if len(filtered_indices) < 1:
+                return jenni.say('No quotes by that nick!')
+
+            filtered_index_index = random.randint(1, len(filtered_indices))
+            number = filtered_indices[filtered_index_index - 1]
+    else:
         number = random.randint(1, MAX)
     if not (0 <= number <= MAX):
         jenni.reply("I'm not sure which quote you would like to see.")


### PR DESCRIPTION
This allows one to say:
```
.quote Nick
```
And jenni to spit out a quote beginning with `<Nick>`, which is the typical format for attributing authors of quotes. It *is* case sensitive, which can be worked around if desired.

A brief explanation of the code:

1. I added an import of `itertools` because of it's handy-dandy `compress` method, that did exactly what I wanted.
2. Updated documentation
3. Checked to see if `text` is not `None`. If so, the user *did* pass an argument, try to treat it as a number. If that works, use that number. If the nick you're trying to reference is a number, sucks. If that didn't work, treat what the user gave as a nick and retrieve the indices of all quotes by that nick. Return an arbitrary one of those indices, if there are any. If there *aren't* any, give up and complain.

    If `text` is `None`, the user did not pass an argument, so just choose a random one.

That may be poorly worded, but that's it. Of course, I'd love feedback.