### PR TITLE
Seen no longer includes anything after first space

### DIFF
--- a/modules/seen.py
+++ b/modules/seen.py
@@ -31,7 +31,7 @@ def f_seen(jenni, input):
         jenni.say(msg)
     else:
         jenni.say("Sorry, I haven't seen %s around." % nick)
-f_seen.commands = ['seen']
+f_seen.rule = r'(?i)^\.(seen)\s+(\w+)'
 f_seen.rate = 15
 
 def f_note(jenni, input):


### PR DESCRIPTION
"seen" used to include all characters. For example, ".seen J3RN         "
would search for "j3rn         ". Also, ".seen not a real nick" would
seach for "not a real nick". Now, the first example will search for
"j3rn" and the latter for "not".