### PR TITLE
docs: Fix a few typos

### DIFF
--- a/modules/imdb.py
+++ b/modules/imdb.py
@@ -81,7 +81,7 @@ def movie(jenni, input):
 
         ## 510 - (16 + 8 + 63)
         ## max_chars (minus \r\n) - (max_nick_length + max_ident_length
-        ##     + max_vhost_lenth_on_freenode)
+        ##     + max_vhost_length_on_freenode)
         max_len_of_plot = 423 - (len(pre_plot) + len(after_plot) + len(truncation))
 
         new_plot = data['Plot']

--- a/modules/search.py
+++ b/modules/search.py
@@ -130,7 +130,7 @@ def duck_search(query):
                     output = result
                     break
         else:
-            ## if we absolustely can't find a URL, let's try scraping the HTML
+            ## if we absolutely can't find a URL, let's try scraping the HTML
             ## page for a zero_click info
             return((duck_zero_click_scrape(page), False))
 

--- a/modules/url.py
+++ b/modules/url.py
@@ -473,7 +473,7 @@ def show_title_auto(jenni, input):
             break
         k += 1
 
-        ## deteremine if we should display the bitly link
+        ## determine if we should display the bitly link
         useBitLy = doUseBitLy(returned_title, orig)
 
         reg_format = '[ %s ] - %s'

--- a/modules/weather.py
+++ b/modules/weather.py
@@ -426,7 +426,7 @@ def f_weather(jenni, input):
             ## if in North America
             windchill = u'%.1f\u00B0F (%.1f\u00B0C)'.encode('utf-8') % (f, windchill)
         else:
-            ## else, anywhere else in the worldd
+            ## else, anywhere else in the world
             windchill = u'%.1f\u00B0C'.encode('utf-8') % (windchill)
 
     heatindex = False
@@ -844,7 +844,7 @@ def forecastio_current_weather(jenni, input):
     humidity = today['humidity']
     APtemp = today['apparentTemperature']
 
-    ## this code is different than the section in the previous sectio
+    ## this code is different than the section in the previous section
     ## as darksky.net uses more precise measurements than NOAA
     if cover >= 0.8:
         cover_word = 'Overcast'

--- a/web.py
+++ b/web.py
@@ -129,7 +129,7 @@ def remove_xml_tags(txt):
 
 def get_urllib_object(uri, timeout):
     '''Return a urllib2 object for `uri` and `timeout`. This is better than
-    using urrlib2 directly, for it handles redirects, makes sure URI is utf8,
+    using urllib2 directly, for it handles redirects, makes sure URI is utf8,
     and is shorter and easier to use.
     Modules may use this if they need a urllib2 object to execute .read() on.
     For more information, refer to the urllib2 documentation.'''


### PR DESCRIPTION
There are small typos in:
- modules/imdb.py
- modules/search.py
- modules/url.py
- modules/weather.py
- web.py

Fixes:
- Should read `world` rather than `worldd`.
- Should read `urllib` rather than `urrlib`.
- Should read `section` rather than `sectio`.
- Should read `length` rather than `lenth`.
- Should read `determine` rather than `deteremine`.
- Should read `absolutely` rather than `absolustely`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md